### PR TITLE
Fixes bug with info not showing up on search

### DIFF
--- a/src/pages/ColumnPage.js
+++ b/src/pages/ColumnPage.js
@@ -47,7 +47,10 @@ export default function ColumnPage({ match }) {
     },
   });
 
-  const filteredEntries = result;
+  let filteredEntries = result;
+  if(result[0] && result[0].item){
+    filteredEntries = result.map(r=>r.item)
+  }
 
   const toggleEnrtySelection = entry => {
     const entryName = typeof entry == 'string' ? entry : entry.name;


### PR DESCRIPTION
Search results come back with a relevance and an item on search. Need to map over that array just to get the item. Should probably sort by relevance as well 